### PR TITLE
Set up Context API

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -3,16 +3,24 @@ import { useNavigate } from 'react-router-dom';
 import SearchIcon from '@mui/icons-material/Search';
 import MicIcon from '@mui/icons-material/Mic';
 import { Button } from '@mui/material';
+import { useStateValue } from '../contextAPI/StateProvider';
+import { actionTypes } from '../contextAPI/reducer';
 import '../styles/Search.css';
 
 function Search({hideButtons}) {
   const [input, setInput] = useState('');
+  const [{}, dispatch] = useStateValue();
 
   const navigate = useNavigate();
 
   const search = (e) => {
     e.preventDefault(); // stog page from refreshing
     console.log("You hit the search button")
+
+    dispatch({
+      type: actionTypes.SET_SEARCH_TERM,
+      term: input,
+    })
 
     navigate("/search")
   }

--- a/src/contextAPI/StateProvider.js
+++ b/src/contextAPI/StateProvider.js
@@ -1,0 +1,14 @@
+import React, { createContext, useContext, useReducer } from "react";
+
+// Preparing the data layer
+export const StateContext = createContext();
+
+// Higher Order container(component). the children is the App component
+export const StateProvider = ({reducer, initialState, children}) => {
+    <StateContext.Provider value={useReducer(reducer, initialState)}>
+        {children}
+    </StateContext.Provider>
+}
+
+// hook which allows us to pull information from the data layer
+export const useStateValue = () => useContext(StateContext)

--- a/src/contextAPI/reducer.js
+++ b/src/contextAPI/reducer.js
@@ -1,0 +1,23 @@
+export const initialState = {
+    term: null,
+}
+
+export const actionTypes = {
+    SET_SEARCH_TERM: "SET_SEARCH_TERM",
+}
+
+const reducer = (state, action) => {
+    console.log(action);
+
+    switch (action.type) {
+        case actionTypes.SET_SEARCH_TERM:
+            return {
+                ...state,
+                term: action.term
+            }
+        default:
+            return state;
+    }
+}
+
+export default reducer;

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './styles/index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { StateProvider } from './contextAPI/StateProvider';
+import reducer, { initialState } from './contextAPI/reducer';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
+    <StateProvider initialState={initialState} reducer={reducer}>
     <App />
+    </StateProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
- Set Up the Context: StateContext is created using createContext() to prepare a global data layer. This is the "container" that holds the app’s state.
- Wrap the app with the StateContext.Provider. The StateProvider Component, a Higher Order Component (HOC)
- Take reducer, initialState, and children (the app components) as props. Provide access to the useReducer hook, which manages the app state and dispatches actions.
- Accessing the Context with the useStateValue; custom hook built using useContext(StateContext) to allow components to access the shared state.